### PR TITLE
Nodereaperd should honor pod grace periods

### DIFF
--- a/nodereaperd/main.go
+++ b/nodereaperd/main.go
@@ -100,11 +100,12 @@ func drainNode(opts *ops, clientset *kubernetes.Clientset) error {
 	err = drain.Drain(clientset, []*core_v1.Node{
 		node,
 	}, &drain.DrainOptions{
-		Force:            true,
-		IgnoreDaemonsets: true,
-		Timeout:          2 * time.Minute,
-		DeleteLocalData:  true,
-		Logger:           &wrappedLogger{logrus.StandardLogger()},
+		Force:              true,
+		IgnoreDaemonsets:   true,
+		GracePeriodSeconds: -1, // set to negative to allow for default pod grace periods
+		Timeout:            2 * time.Minute,
+		DeleteLocalData:    true,
+		Logger:             &wrappedLogger{logrus.StandardLogger()},
 	})
 	if err != nil {
 		return fmt.Errorf("Error draining pods from node %v: %v", opts.NodeName, err)


### PR DESCRIPTION
The k8s API by default honors the grace period of pods if you don't pass
in a grace period
(https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#DeleteOptions)
but the openshift wrap this is using defaults to 0 (meaning terminate
immediately--
https://github.com/openshift/kubernetes-drain/blob/master/drain.go#L56).
According to the openshift lib we need to set this to -1 to leave the
value blank when sending to k8s.