### PR TITLE
Nodereaper should delete ASG instances with no associated config/tmpl

### DIFF
--- a/pkg/aws/aws.go
+++ b/pkg/aws/aws.go
@@ -72,6 +72,10 @@ func (d *APIProvider) sync() {
 				} else if instance.LaunchTemplate != nil {
 					launchTemplate := fmt.Sprintf("%v-%v", *instance.LaunchTemplate.LaunchTemplateId, *instance.LaunchTemplate.Version)
 					d.nodeInstanceConfiguration[*instance.InstanceId] = &launchTemplate
+				} else {
+					// In this case, the launch config/template is so old it literally doesn't exist
+					// so we know that it's outdated
+					d.nodeInstanceConfiguration[*instance.InstanceId] = nil
 				}
 			}
 		}


### PR DESCRIPTION
This fixes a regression introduced in #1, where instances in an ASG which have no associated launch config or launch template are not deleted, even though this definitely means they are outdated.