### PR TITLE
Delete oldest nodes first

### DIFF
--- a/pkg/deletion/deletion.go
+++ b/pkg/deletion/deletion.go
@@ -129,8 +129,9 @@ func (d *Deleter) pollDeletions() {
 				state = oldState.State
 			}
 			d.states.Groups[groupKey].Nodes[node.Name] = &NodeState{
-				Name:  node.Name,
-				State: state,
+				Name:         node.Name,
+				State:        state,
+				CreationTime: node.CreationTimestamp,
 			}
 		}
 	}


### PR DESCRIPTION
In situations where nodereaper cannot keep up with the number of deletions required, it makes sense to prioritize the oldest nodes, to ensure that every node is at least rolled eventually. 